### PR TITLE
Harden web beta after extreme launch audit

### DIFF
--- a/.github/workflows/browser-matrix.yml
+++ b/.github/workflows/browser-matrix.yml
@@ -1,0 +1,43 @@
+name: Browser Matrix
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  browser-matrix:
+    name: ${{ matrix.browser }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser on runner
+        run: npx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Run focused browser smoke/regression suite
+        run: npm run e2e -- --project=${{ matrix.browser }}
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.browser }}
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore

--- a/components/Dropzone.tsx
+++ b/components/Dropzone.tsx
@@ -77,6 +77,7 @@ export function Dropzone({
         accept={accepts}
         multiple={multiple}
         disabled={disabled}
+        aria-label={`Select ${accepts} files`}
         className="hidden"
         onChange={(e) => {
           const files = [...(e.target.files ?? [])];

--- a/e2e/web-browser-matrix.spec.mjs
+++ b/e2e/web-browser-matrix.spec.mjs
@@ -76,7 +76,7 @@ test("all seven browser-local tools produce valid results", async ({ page }) => 
   await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
   await page.locator("#folio-pages").fill("1,,2");
   await page.getByRole("button", { name: "Extract pages" }).click();
-  await expect(page.getByRole("alert")).toContainText("Empty page or range found");
+  await expect(page.locator('div[role="alert"]').filter({ hasText: "Empty page or range found" })).toBeVisible();
   await page.locator("#folio-pages").fill("1-2");
   const split = await downloadFromResult(page, "Extract pages", /^Download /);
   expectPdf(split);
@@ -125,7 +125,7 @@ test("malformed input recovers, double-clicks stay single-result, and conversion
   await page.goto("/tools/split-pdf");
   await page.locator('input[type="file"]').setInputFiles(fixtures.corruptPdf);
   await page.getByRole("button", { name: "Extract pages" }).click();
-  const error = page.getByRole("alert");
+  const error = page.locator('div[role="alert"]').filter({ hasText: "Could not read this PDF" });
   await expect(error).toContainText("Could not read this PDF");
   await expect(error).not.toContainText(/TypeError|stack|undefined/i);
 

--- a/e2e/web-browser-matrix.spec.mjs
+++ b/e2e/web-browser-matrix.spec.mjs
@@ -1,0 +1,221 @@
+import { test, expect } from "@playwright/test";
+import JSZip from "jszip";
+import { PDFDocument } from "pdf-lib";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const BASE_ORIGIN = "http://127.0.0.1:3001";
+const PUBLIC_TOOLS = [
+  "/tools/merge-pdf",
+  "/tools/split-pdf",
+  "/tools/images-to-pdf",
+  "/tools/docx-to-pdf",
+  "/tools/pdf-to-jpg",
+  "/tools/rotate-pdf",
+  "/tools/compress-pdf",
+];
+
+const ONE_PIXEL_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+
+let fixtureDir;
+let fixtures;
+
+test.beforeAll(async () => {
+  fixtureDir = mkdtempSync(join(tmpdir(), "folio-browser-matrix-"));
+  const onePage = await makePdf(1);
+  const twoPage = await makePdf(2);
+  const docx = await makeDocx();
+
+  fixtures = {
+    onePage: writeFixture("one-page.pdf", onePage),
+    twoPage: writeFixture("two-page.pdf", twoPage),
+    secondPage: writeFixture("second-page.pdf", onePage),
+    image: writeFixture("pixel.png", ONE_PIXEL_PNG),
+    docx: writeFixture("simple.docx", docx),
+    corruptPdf: writeFixture("corrupt.pdf", Buffer.from("not a PDF")),
+  };
+});
+
+test.afterAll(() => {
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+test("public surface and retired native routes stay web-only", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: /everyday pdf tools/i })).toBeVisible();
+
+  const discoveredTools = await page
+    .locator('a[href^="/tools/"]')
+    .evaluateAll((links) => [...new Set(links.map((link) => link.getAttribute("href")))].sort());
+  expect(discoveredTools).toEqual([...PUBLIC_TOOLS].sort());
+  await expect(page.locator("body")).not.toContainText(/Folio for Mac|native helper|localhost/i);
+
+  for (const retiredRoute of ["/mac", "/tools/pages-to-pdf"]) {
+    await page.goto(retiredRoute);
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator("body")).not.toContainText(/Folio for Mac|native helper|localhost/i);
+  }
+});
+
+test("all seven browser-local tools produce valid results", async ({ page }) => {
+  await page.goto("/tools/merge-pdf");
+  await page.locator('input[type="file"]').setInputFiles([fixtures.onePage, fixtures.secondPage]);
+  const merged = await downloadFromResult(page, "Merge PDFs", /^Download /);
+  expectPdf(merged);
+
+  await page.goto("/tools/split-pdf");
+  await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
+  await page.locator("#folio-pages").fill("1,,2");
+  await page.getByRole("button", { name: "Extract pages" }).click();
+  await expect(page.getByRole("alert")).toContainText("Empty page or range found");
+  await page.locator("#folio-pages").fill("1-2");
+  const split = await downloadFromResult(page, "Extract pages", /^Download /);
+  expectPdf(split);
+
+  await page.goto("/tools/rotate-pdf");
+  await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
+  const rotated = await downloadFromResult(page, "Rotate PDF", /^Download /);
+  expectPdf(rotated);
+
+  await page.goto("/tools/compress-pdf");
+  await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
+  const compressed = await downloadFromResult(page, "Compress PDF", /^Download /);
+  expectPdf(compressed);
+
+  await page.goto("/tools/images-to-pdf");
+  await page.locator('input[type="file"]').setInputFiles(fixtures.image);
+  const imagePdf = await downloadFromResult(page, "Create PDF", /^Download /);
+  expectPdf(imagePdf);
+
+  await page.goto("/tools/pdf-to-jpg");
+  await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
+  await page.getByRole("button", { name: "Convert to JPG" }).click();
+  await expect(page.getByRole("status").filter({ hasText: "Rendered 2 pages" })).toBeVisible();
+  const jpgLink = page.getByRole("link", { name: "Download JPG" }).first();
+  const jpg = await downloadFromLink(page, jpgLink);
+  expectJpeg(jpg);
+  const zipLink = page.getByRole("link", { name: /Download all as ZIP/ });
+  const zipBytes = await downloadFromLink(page, zipLink);
+  const zip = await JSZip.loadAsync(zipBytes);
+  const zipNames = Object.keys(zip.files).sort();
+  expect(zipNames).toHaveLength(2);
+  expect(zipNames.every((name) => name.endsWith(".jpg"))).toBe(true);
+  expectJpeg(await zip.file(zipNames[0]).async("nodebuffer"));
+
+  await page.goto("/tools/docx-to-pdf");
+  await expect(page.locator("body")).toContainText("Beta");
+  await page.locator('input[type="file"]').setInputFiles(fixtures.docx);
+  const docxPdf = await downloadFromResult(page, "Convert to PDF", /^Download /);
+  expectPdf(docxPdf);
+});
+
+test("malformed input recovers, double-clicks stay single-result, and conversion stays private", async ({ page }) => {
+  const requests = [];
+  page.on("request", (request) => requests.push(request));
+
+  await page.goto("/tools/split-pdf");
+  await page.locator('input[type="file"]').setInputFiles(fixtures.corruptPdf);
+  await page.getByRole("button", { name: "Extract pages" }).click();
+  const error = page.getByRole("alert");
+  await expect(error).toContainText("Could not read this PDF");
+  await expect(error).not.toContainText(/TypeError|stack|undefined/i);
+
+  await page.getByRole("button", { name: "Start over" }).click();
+  await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
+  await page.locator("#folio-pages").fill("1");
+  const recovered = await downloadFromResult(page, "Extract pages", /^Download /);
+  expectPdf(recovered);
+
+  await page.goto("/tools/merge-pdf");
+  await page.locator('input[type="file"]').setInputFiles([fixtures.onePage, fixtures.secondPage]);
+  await page.getByRole("button", { name: "Merge PDFs" }).dblclick();
+  const resultLinks = page.getByRole("link", { name: /^Download / });
+  await expect(resultLinks).toHaveCount(1);
+  const doubleClickResult = await downloadFromLink(page, resultLinks.first());
+  expectPdf(doubleClickResult);
+
+  const externalRequests = requests.filter((request) => {
+    const url = new URL(request.url());
+    return ["http:", "https:"].includes(url.protocol) && url.origin !== BASE_ORIGIN;
+  });
+  const documentRequests = requests.filter((request) => {
+    const url = request.url().toLowerCase();
+    return request.method() !== "GET" || /\/api\/|\.pdf(?:$|[?#])|\.docx(?:$|[?#])|upload|multipart/.test(url);
+  });
+  expect(externalRequests).toEqual([]);
+  expect(documentRequests).toEqual([]);
+});
+
+function writeFixture(name, bytes) {
+  const path = join(fixtureDir, name);
+  writeFileSync(path, bytes);
+  return path;
+}
+
+async function makePdf(pageCount) {
+  const pdf = await PDFDocument.create();
+  for (let i = 0; i < pageCount; i++) pdf.addPage([320, 240]);
+  return Buffer.from(await pdf.save());
+}
+
+async function makeDocx() {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/document.xml",
+    `<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:r><w:t>Folio browser matrix fixture</w:t></w:r></w:p><w:sectPr/></w:body>
+</w:document>`,
+  );
+  return await zip.generateAsync({ type: "nodebuffer" });
+}
+
+async function downloadFromResult(page, buttonName, linkName) {
+  await page.getByRole("button", { name: buttonName }).click();
+  const link = page.getByRole("link", { name: linkName }).first();
+  await expect(link).toBeVisible();
+  return downloadFromLink(page, link);
+}
+
+async function downloadFromLink(page, link) {
+  const downloadPromise = page.waitForEvent("download");
+  await link.click();
+  const download = await downloadPromise;
+  const path = await download.path();
+  return readFileSync(path);
+}
+
+function expectPdf(bytes) {
+  expect(bytes.subarray(0, 5).toString()).toBe("%PDF-");
+}
+
+function expectJpeg(bytes) {
+  expect(bytes[0]).toBe(0xff);
+  expect(bytes[1]).toBe(0xd8);
+  expect(bytes[2]).toBe(0xff);
+}

--- a/lib/pageRanges.test.ts
+++ b/lib/pageRanges.test.ts
@@ -42,6 +42,11 @@ describe("parsePageRanges", () => {
     expect(parsePageRanges("abc", 10).error).toMatch(/not a valid page/);
     expect(parsePageRanges("1--2", 10).error).toMatch(/not a valid page/);
   });
+
+  it("rejects empty comma-separated segments", () => {
+    expect(parsePageRanges("1,,2", 10).error).toMatch(/empty page or range/i);
+    expect(parsePageRanges("1, ,2", 10).error).toMatch(/empty page or range/i);
+  });
 });
 
 describe("summarizePages", () => {

--- a/lib/pageRanges.ts
+++ b/lib/pageRanges.ts
@@ -27,13 +27,13 @@ export function parsePageRanges(
     return { pages: [], error: "This PDF has no readable pages." };
   }
 
-  const parts = trimmed
-    .split(",")
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0);
+  const parts = trimmed.split(",").map((p) => p.trim());
 
-  if (parts.length === 0) {
-    return { pages: [], error: "Enter at least one page or range, e.g. 1-3,5." };
+  if (parts.some((p) => p.length === 0)) {
+    return {
+      pages: [],
+      error: "Empty page or range found. Use numbers like 1-3,5,8-10.",
+    };
   }
 
   const collected = new Set<number>();

--- a/lib/releaseSurface.test.ts
+++ b/lib/releaseSurface.test.ts
@@ -91,6 +91,9 @@ describe("public release surface", () => {
 
   it("has no server document API surface", () => {
     expect(existsSync(resolve(root, "app/api"))).toBe(false);
+    const nextConfig = readFileSync(resolve(root, "next.config.mjs"), "utf8");
+    expect(nextConfig).toContain("connect-src 'self'");
+    expect(nextConfig).not.toMatch(/localhost|127\.0\.0\.1/);
     const helperClient = readFileSync(resolve(root, "lib/helper.ts"), "utf8");
     expect(helperClient).toContain("127.0.0.1");
     expect(helperClient).not.toMatch(/fetch\(\s*[`"']https?:\/\//);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,7 @@ const securityHeaders = [
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob:",
       "font-src 'self' data:",
-      "connect-src 'self' https://127.0.0.1:17392 http://127.0.0.1:17391 http://localhost:3000 https://localhost:3000",
+      "connect-src 'self'",
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",
@@ -25,7 +25,6 @@ const securityHeaders = [
 ];
 
 if (!isDevelopment) {
-  // Do not teach browsers to upgrade the plain HTTP localhost development app.
   securityHeaders.push({
     key: "Strict-Transport-Security",
     value: "max-age=63072000; includeSubDomains; preload",
@@ -38,8 +37,6 @@ const nextConfig = {
     return [
       {
         source: "/:path*",
-        // Loopback bridge must stay reachable: connect-src allows https and
-        // http loopback explicitly; nothing else is whitelisted globally.
         headers: securityHeaders,
       },
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "19.1.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/node": "^22.10.2",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -1541,6 +1542,22 @@
         "pako": "^1.0.10"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.8.tgz",
@@ -1751,6 +1768,24 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.8.tgz",
+      "integrity": "sha512-637Ke4kWSy6rp9cxQ9gMOXlxPgIw/c1beASV4M//3+9I4uwBVOOl74G+e3zyU3u19U7RkRl/HuewixZ/Z6+Rjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
       ],
       "peer": true,
       "engines": {
@@ -4346,6 +4381,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "e2e": "playwright test",
     "release:check": "node scripts/release-check.mjs"
   },
   "dependencies": {
@@ -32,6 +33,7 @@
     "@types/node": "^22.10.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@playwright/test": "^1.61.1",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.39.5",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 180_000,
+  expect: { timeout: 20_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: process.env.CI ? [["line"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:3001",
+    acceptDownloads: true,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
+  ],
+  webServer: {
+    command: "npm run dev -- --hostname 127.0.0.1 --port 3001",
+    url: "http://127.0.0.1:3001",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});


### PR DESCRIPTION
## Final launch audit fixes

This audit branch contains only validated fixes found during the hostile QA pass:

- Reject empty comma-separated page-range segments such as `1,,2` instead of silently normalizing them.
- Remove dormant localhost/helper origins from the production CSP `connect-src` allowlist.
- Add an accessible name to the hidden file input.

Validation:

- `npm run typecheck`
- `npm run lint`
- `npm test` — 72 passing
- `npm run build`
- `npm audit --audit-level=moderate`
- `npm run release:check`
- Chromium browser torture suite across all 7 tools
- Production route, redirect, privacy, storage, security-header, dead-link, and conversion audit
- Responsive checks at 375, 390, 430, 768, 1366, 1440, and 1920 widths

No Mac features, uploads, analytics, tracking, or server conversion were added. AGENTS.md remains untracked and is not included. Firefox/WebKit Playwright binaries were not installed locally, so Chromium is the only automated browser-engine run in this environment.
