### PR TITLE
fix: stabilize and polish current browser tools

### DIFF
--- a/components/Dropzone.tsx
+++ b/components/Dropzone.tsx
@@ -81,8 +81,11 @@ export function Dropzone({
         className="hidden"
         onChange={(e) => {
           const files = [...(e.target.files ?? [])];
-          e.target.value = "";
           if (files.length > 0) onFiles(files);
+          // Clear after dispatching the File objects. This preserves the
+          // native picker-backed handles long enough for callers to snapshot
+          // them on Safari before the input is reset.
+          e.target.value = "";
         }}
       />
     </div>
@@ -97,11 +100,13 @@ export interface ListedFile {
 export function FileList({
   items,
   reorderable,
+  disabled,
   onRemove,
   onMove,
 }: {
   items: ListedFile[];
   reorderable: boolean;
+  disabled?: boolean;
   onRemove: (id: string) => void;
   onMove: (id: string, dir: -1 | 1) => void;
 }) {
@@ -125,7 +130,7 @@ export function FileList({
             <div className="flex shrink-0 gap-1" role="group" aria-label={`Reorder ${item.file.name}`}>
               <button
                 type="button"
-                disabled={i === 0}
+                disabled={disabled || i === 0}
                 onClick={() => onMove(item.id, -1)}
                 aria-label={`Move ${item.file.name} up`}
                 className="rounded-lg border border-slate-200 px-2 py-1 text-sm hover:bg-slate-50 disabled:opacity-30"
@@ -134,7 +139,7 @@ export function FileList({
               </button>
               <button
                 type="button"
-                disabled={i === items.length - 1}
+                disabled={disabled || i === items.length - 1}
                 onClick={() => onMove(item.id, 1)}
                 aria-label={`Move ${item.file.name} down`}
                 className="rounded-lg border border-slate-200 px-2 py-1 text-sm hover:bg-slate-50 disabled:opacity-30"
@@ -145,6 +150,7 @@ export function FileList({
           )}
           <button
             type="button"
+            disabled={disabled}
             onClick={() => onRemove(item.id)}
             aria-label={`Remove ${item.file.name}`}
             className="shrink-0 rounded-lg border border-slate-200 px-2.5 py-1 text-sm text-red-700 hover:bg-red-50"

--- a/components/ToolRunner.tsx
+++ b/components/ToolRunner.tsx
@@ -14,6 +14,7 @@ import {
 import {
   formatBytes,
   formatPercentChange,
+  readFileBytes,
   safeFileName,
   validateFiles,
   withExtension,
@@ -49,6 +50,7 @@ export function ToolRunner({ tool }: { tool: FolioTool }) {
   const [rotateMode, setRotateMode] = useState<"all" | "pages">("all");
   const [degrees, setDegrees] = useState<RotationDegrees>(90);
   const [zipMeta, setZipMeta] = useState<{ name: string; size: number } | null>(null);
+  const runGuardRef = useRef(false);
   const fileObjs = useMemo(() => files.map((f) => f.file), [files]);
 
   // Single registry for every object URL this component creates, so cleanup
@@ -115,16 +117,20 @@ export function ToolRunner({ tool }: { tool: FolioTool }) {
     [resetResults],
   );
 
-  const moveFile = useCallback((id: string, dir: -1 | 1) => {
-    setFiles((prev) => {
-      const i = prev.findIndex((f) => f.id === id);
-      const j = i + dir;
-      if (i < 0 || j < 0 || j >= prev.length) return prev;
-      const next = [...prev];
-      [next[i], next[j]] = [next[j], next[i]];
-      return next;
-    });
-  }, []);
+  const moveFile = useCallback(
+    (id: string, dir: -1 | 1) => {
+      setFiles((prev) => {
+        const i = prev.findIndex((f) => f.id === id);
+        const j = i + dir;
+        if (i < 0 || j < 0 || j >= prev.length) return prev;
+        const next = [...prev];
+        [next[i], next[j]] = [next[j], next[i]];
+        return next;
+      });
+      resetResults();
+    },
+    [resetResults],
+  );
 
   const startOver = useCallback(() => {
     resetResults();
@@ -133,6 +139,8 @@ export function ToolRunner({ tool }: { tool: FolioTool }) {
   }, [resetResults]);
 
   async function run(): Promise<void> {
+    if (runGuardRef.current) return;
+    runGuardRef.current = true;
     setError(null);
     resetResults();
     setBusy(true);
@@ -159,7 +167,7 @@ export function ToolRunner({ tool }: { tool: FolioTool }) {
           setProgress("Reading PDF…");
           const { getPdfPageCount, splitPdf } = await import("@/lib/pdfOps");
           const count = await getPdfPageCount(
-            new Uint8Array(await file.arrayBuffer()),
+            await readFileBytes(file),
           );
           const parsed = parsePageRanges(rangeText, count);
           if (parsed.error) throw new Error(parsed.error);
@@ -267,7 +275,7 @@ export function ToolRunner({ tool }: { tool: FolioTool }) {
           let targets: number[] | null = null;
           if (rotateMode === "pages") {
             const count = await getPdfPageCount(
-              new Uint8Array(await file.arrayBuffer()),
+              await readFileBytes(file),
             );
             const parsed = parsePageRanges(rangeText, count);
             if (parsed.error) throw new Error(parsed.error);
@@ -303,8 +311,14 @@ export function ToolRunner({ tool }: { tool: FolioTool }) {
         }
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Something went wrong.");
+      const message = e instanceof Error ? e.message : "Something went wrong.";
+      setError(
+        /I\/O read operation failed|NotReadableError/i.test(message)
+          ? "We couldn’t read this file. Remove it and select it again."
+          : message,
+      );
     } finally {
+      runGuardRef.current = false;
       setBusy(false);
       setProgress("");
     }
@@ -319,7 +333,7 @@ export function ToolRunner({ tool }: { tool: FolioTool }) {
         : fileObjs.length === 1);
 
   return (
-    <div className="mx-auto max-w-3xl px-5 py-10">
+    <div className="mx-auto max-w-3xl px-5 py-10" aria-busy={busy}>
       <ToolHeader
         name={tool.name}
         description={tool.longDescription}
@@ -347,6 +361,7 @@ export function ToolRunner({ tool }: { tool: FolioTool }) {
         <FileList
           items={files}
           reorderable={tool.multiple && files.length > 1}
+          disabled={busy}
           onRemove={removeFile}
           onMove={moveFile}
         />
@@ -448,7 +463,7 @@ export function ToolRunner({ tool }: { tool: FolioTool }) {
           <PrimaryButton onClick={run} disabled={!canRun}>
             {busy ? "Working…" : actionLabel(tool.slug)}
           </PrimaryButton>
-          {(files.length > 0 || result) && (
+          {(files.length > 0 || result || complaints.length > 0 || error) && (
             <SecondaryButton onClick={startOver} disabled={busy}>
               Start over
             </SecondaryButton>

--- a/e2e/web-browser-matrix.spec.mjs
+++ b/e2e/web-browser-matrix.spec.mjs
@@ -70,7 +70,7 @@ test("all seven browser-local tools produce valid results", async ({ page }) => 
   await page.goto("/tools/merge-pdf");
   await page.locator('input[type="file"]').setInputFiles([fixtures.onePage, fixtures.secondPage]);
   const merged = await downloadFromResult(page, "Merge PDFs", /^Download /);
-  expectPdf(merged);
+  await expectPdf(merged, 2);
 
   await page.goto("/tools/split-pdf");
   await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
@@ -79,22 +79,22 @@ test("all seven browser-local tools produce valid results", async ({ page }) => 
   await expect(page.locator('div[role="alert"]').filter({ hasText: "Empty page or range found" })).toBeVisible();
   await page.locator("#folio-pages").fill("1-2");
   const split = await downloadFromResult(page, "Extract pages", /^Download /);
-  expectPdf(split);
+  await expectPdf(split, 2);
 
   await page.goto("/tools/rotate-pdf");
   await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
   const rotated = await downloadFromResult(page, "Rotate PDF", /^Download /);
-  expectPdf(rotated);
+  await expectPdf(rotated, 2);
 
   await page.goto("/tools/compress-pdf");
   await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
   const compressed = await downloadFromResult(page, "Compress PDF", /^Download /);
-  expectPdf(compressed);
+  await expectPdf(compressed, 2);
 
   await page.goto("/tools/images-to-pdf");
   await page.locator('input[type="file"]').setInputFiles(fixtures.image);
   const imagePdf = await downloadFromResult(page, "Create PDF", /^Download /);
-  expectPdf(imagePdf);
+  await expectPdf(imagePdf, 1);
 
   await page.goto("/tools/pdf-to-jpg");
   await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
@@ -115,7 +115,29 @@ test("all seven browser-local tools produce valid results", async ({ page }) => 
   await expect(page.locator("body")).toContainText("Beta");
   await page.locator('input[type="file"]').setInputFiles(fixtures.docx);
   const docxPdf = await downloadFromResult(page, "Convert to PDF", /^Download /);
-  expectPdf(docxPdf);
+  await expectPdf(docxPdf, 1);
+});
+
+test("same PDF selected twice survives a WebKit-style read failure", async ({ page }) => {
+  await page.addInitScript(() => {
+    const nativeArrayBuffer = File.prototype.arrayBuffer;
+    let injected = false;
+    File.prototype.arrayBuffer = function () {
+      if (!injected) {
+        injected = true;
+        return Promise.reject(
+          new DOMException("The I/O read operation failed.", "NotReadableError"),
+        );
+      }
+      return nativeArrayBuffer.call(this);
+    };
+  });
+
+  await page.goto("/tools/merge-pdf");
+  await page.locator('input[type="file"]').setInputFiles([fixtures.onePage, fixtures.onePage]);
+  const merged = await downloadFromResult(page, "Merge PDFs", /^Download /);
+  await expectPdf(merged, 2);
+  await expect(page.locator('[role="alert"]')).not.toContainText(/I\/O read operation failed/);
 });
 
 test("malformed input recovers, double-clicks stay single-result, and conversion stays private", async ({ page }) => {
@@ -129,11 +151,21 @@ test("malformed input recovers, double-clicks stay single-result, and conversion
   await expect(error).toContainText("Could not read this PDF");
   await expect(error).not.toContainText(/TypeError|stack|undefined/i);
 
+  await page.goto("/tools/merge-pdf");
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "wrong.png",
+    mimeType: "image/png",
+    buffer: readFileSync(fixtures.onePage),
+  });
+  await expect(page.getByRole("alert").filter({ hasText: "accepts .pdf" })).toBeVisible();
   await page.getByRole("button", { name: "Start over" }).click();
+  await expect(page.getByRole("alert").filter({ hasText: "accepts .pdf" })).toHaveCount(0);
+
+  await page.goto("/tools/split-pdf");
   await page.locator('input[type="file"]').setInputFiles(fixtures.twoPage);
   await page.locator("#folio-pages").fill("1");
   const recovered = await downloadFromResult(page, "Extract pages", /^Download /);
-  expectPdf(recovered);
+  await expectPdf(recovered, 1);
 
   await page.goto("/tools/merge-pdf");
   await page.locator('input[type="file"]').setInputFiles([fixtures.onePage, fixtures.secondPage]);
@@ -141,7 +173,7 @@ test("malformed input recovers, double-clicks stay single-result, and conversion
   const resultLinks = page.getByRole("link", { name: /^Download / });
   await expect(resultLinks).toHaveCount(1);
   const doubleClickResult = await downloadFromLink(page, resultLinks.first());
-  expectPdf(doubleClickResult);
+  await expectPdf(doubleClickResult, 2);
 
   const externalRequests = requests.filter((request) => {
     const url = new URL(request.url());
@@ -210,8 +242,11 @@ async function downloadFromLink(page, link) {
   return readFileSync(path);
 }
 
-function expectPdf(bytes) {
+async function expectPdf(bytes, expectedPages) {
   expect(bytes.subarray(0, 5).toString()).toBe("%PDF-");
+  expect(bytes.length).toBeGreaterThan(100);
+  const pdf = await PDFDocument.load(bytes);
+  if (expectedPages !== undefined) expect(pdf.getPageCount()).toBe(expectedPages);
 }
 
 function expectJpeg(bytes) {

--- a/lib/files.test.ts
+++ b/lib/files.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatBytes,
   formatPercentChange,
+  readFileBytes,
   safeFileName,
   validateFiles,
   withExtension,
@@ -40,6 +41,30 @@ describe("safeFileName / withExtension", () => {
 
   it("falls back on hostile names", () => {
     expect(safeFileName("...")).toBe("folio-output");
+  });
+});
+
+describe("readFileBytes", () => {
+  it("returns an independent byte snapshot", async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], "sample.pdf");
+    const first = await readFileBytes(file);
+    first[0] = 99;
+    const second = await readFileBytes(file);
+
+    expect([...second]).toEqual([1, 2, 3]);
+  });
+
+  it("hides low-level read failures behind an actionable error", async () => {
+    const unreadable = {
+      arrayBuffer: async () => {
+        throw new DOMException("The I/O read operation failed.", "NotReadableError");
+      },
+    } as unknown as Blob;
+
+    await expect(readFileBytes(unreadable)).rejects.toMatchObject({
+      name: "FileReadError",
+      message: "We couldn’t read this file. Remove it and select it again.",
+    });
   });
 });
 

--- a/lib/files.ts
+++ b/lib/files.ts
@@ -45,6 +45,66 @@ export function withExtension(base: string, ext: string): string {
 }
 
 /**
+ * Read a local Blob/File into an independent byte snapshot.
+ *
+ * Safari can reject Blob.arrayBuffer() with NotReadableError for some
+ * picker-backed files. FileReader uses a separate compatibility path and
+ * keeps the low-level browser exception out of the user-facing UI. The copy
+ * also means downstream parsers never share a browser-owned buffer.
+ */
+export async function readFileBytes(blob: Blob): Promise<Uint8Array> {
+  let nativeError: unknown;
+  try {
+    const buffer = await blob.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+    const copy = new Uint8Array(bytes.length);
+    copy.set(bytes);
+    return copy;
+  } catch (error) {
+    nativeError = error;
+  }
+
+  if (typeof FileReader === "function") {
+    try {
+      const buffer = await new Promise<ArrayBuffer>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          if (reader.result instanceof ArrayBuffer) resolve(reader.result);
+          else reject(new Error("The browser returned no readable file data."));
+        };
+        reader.onerror = () => reject(reader.error ?? new Error("FileReader failed."));
+        reader.onabort = () => reject(new Error("The file read was aborted."));
+        reader.readAsArrayBuffer(blob);
+      });
+      const bytes = new Uint8Array(buffer);
+      const copy = new Uint8Array(bytes.length);
+      copy.set(bytes);
+      return copy;
+    } catch (fallbackError) {
+      throw new FileReadError(
+        "We couldn’t read this file. Remove it and select it again.",
+        { nativeError, fallbackError },
+      );
+    }
+  }
+
+  throw new FileReadError(
+    "We couldn’t read this file. Remove it and select it again.",
+    nativeError,
+  );
+}
+
+export class FileReadError extends Error {
+  readonly cause: unknown;
+
+  constructor(message: string, cause: unknown) {
+    super(message);
+    this.name = "FileReadError";
+    this.cause = cause;
+  }
+}
+
+/**
  * Validate candidate files against a tool's rules.
  * Returns the accepted files plus human-readable complaints.
  */

--- a/lib/pdfOps.test.ts
+++ b/lib/pdfOps.test.ts
@@ -48,6 +48,13 @@ describe("pdf engine", () => {
     expect([...out.slice(0, 5)]).toEqual([0x25, 0x50, 0x44, 0x46, 0x2d]);
   });
 
+  it("merges the same File object twice", async () => {
+    const source = await makePdf(2);
+    const out = await mergePdfs([source, source]);
+
+    expect(await getPdfPageCount(out)).toBe(4);
+  });
+
   it("splits out exactly the requested pages", async () => {
     const src = await makePdf(6);
     const out = await splitPdf(src, [1, 3, 5]);

--- a/lib/pdfOps.ts
+++ b/lib/pdfOps.ts
@@ -6,6 +6,8 @@
  * Heavy libraries are dynamically imported so the homepage stays light.
  */
 
+import { readFileBytes } from "./files";
+
 export async function getPdfPageCount(data: Uint8Array): Promise<number> {
   const doc = await loadPdfDocument(data);
   return doc.getPageCount();
@@ -64,7 +66,7 @@ export async function mergePdfs(files: File[]): Promise<Uint8Array> {
   const { PDFDocument } = await import("pdf-lib");
   const out = await PDFDocument.create();
   for (const file of files) {
-    const bytes = new Uint8Array(await file.arrayBuffer());
+    const bytes = await readFileBytes(file);
     const src = await loadPdfDocument(bytes);
     const pages = await out.copyPages(src, src.getPageIndices());
     for (const p of pages) out.addPage(p);
@@ -77,7 +79,7 @@ export async function splitPdf(
   keepPages1Based: number[],
 ): Promise<Uint8Array> {
   const { PDFDocument } = await import("pdf-lib");
-  const bytes = new Uint8Array(await file.arrayBuffer());
+  const bytes = await readFileBytes(file);
   const src = await loadPdfDocument(bytes);
   const out = await PDFDocument.create();
   const indices = [...new Set(keepPages1Based.map((p) => p - 1))]
@@ -98,7 +100,7 @@ export async function rotatePdf(
   degrees: RotationDegrees,
 ): Promise<Uint8Array> {
   const { degrees: toDegrees } = await import("pdf-lib");
-  const bytes = new Uint8Array(await file.arrayBuffer());
+  const bytes = await readFileBytes(file);
   const doc = await loadPdfDocument(bytes);
   const count = doc.getPageCount();
   const targets =
@@ -129,7 +131,7 @@ export interface OptimizeResult {
  */
 export async function optimizePdf(file: File): Promise<OptimizeResult> {
   const beforeBytes = file.size;
-  const bytes = new Uint8Array(await file.arrayBuffer());
+  const bytes = await readFileBytes(file);
   const doc = await loadPdfDocument(bytes);
   doc.setProducer("Folio");
   doc.setCreator("Folio (local processing)");
@@ -177,7 +179,7 @@ export async function imagesToPdf(files: File[]): Promise<Uint8Array> {
   const margin = 24;
 
   for (const file of files) {
-    const raw = new Uint8Array(await file.arrayBuffer());
+    const raw = await readFileBytes(file);
     const isPng =
       file.type === "image/png" || /\.png$/i.test(file.name);
     let embedded;
@@ -201,7 +203,7 @@ export async function imagesToPdf(files: File[]): Promise<Uint8Array> {
           canvas.toBlob(res, "image/jpeg", 0.92),
         );
         if (!blob) throw new Error(`Could not read ${file.name}.`);
-        const buf = new Uint8Array(await blob.arrayBuffer());
+        const buf = await readFileBytes(blob);
         embedded = await doc.embedJpg(buf);
       } finally {
         URL.revokeObjectURL(url);
@@ -255,7 +257,7 @@ export async function renderPdfPages(
     pdfjs.GlobalWorkerOptions.workerSrc = PDF_WORKER_SRC;
   }
 
-  const data = new Uint8Array(await file.arrayBuffer());
+  const data = await readFileBytes(file);
   let pdf;
   try {
     const loading = pdfjs.getDocument({ data });
@@ -267,26 +269,28 @@ export async function renderPdfPages(
   }
   const out: RenderedPage[] = [];
   const scale = opts.scale ?? 2;
-
-  for (let n = 1; n <= pdf.numPages; n++) {
-    const page = await pdf.getPage(n);
-    const viewport = page.getViewport({ scale });
-    const canvas = document.createElement("canvas");
-    canvas.width = Math.ceil(viewport.width);
-    canvas.height = Math.ceil(viewport.height);
-    const ctx = canvas.getContext("2d");
-    if (!ctx) throw new Error("Canvas unavailable in this browser.");
-    await page.render({ canvasContext: ctx, viewport }).promise;
-    const blob = await new Promise<Blob | null>((res) =>
-      canvas.toBlob(res, "image/jpeg", 0.92),
-    );
-    if (!blob) throw new Error(`Could not render page ${n}.`);
-    out.push({ pageNumber: n, blob, width: canvas.width, height: canvas.height });
-    opts.onProgress?.(n, pdf.numPages);
-    page.cleanup();
+  try {
+    for (let n = 1; n <= pdf.numPages; n++) {
+      const page = await pdf.getPage(n);
+      const viewport = page.getViewport({ scale });
+      const canvas = document.createElement("canvas");
+      canvas.width = Math.ceil(viewport.width);
+      canvas.height = Math.ceil(viewport.height);
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("Canvas unavailable in this browser.");
+      await page.render({ canvasContext: ctx, viewport }).promise;
+      const blob = await new Promise<Blob | null>((res) =>
+        canvas.toBlob(res, "image/jpeg", 0.92),
+      );
+      if (!blob) throw new Error(`Could not render page ${n}.`);
+      out.push({ pageNumber: n, blob, width: canvas.width, height: canvas.height });
+      opts.onProgress?.(n, pdf.numPages);
+      page.cleanup();
+    }
+    return out;
+  } finally {
+    await pdf.destroy();
   }
-  await pdf.destroy();
-  return out;
 }
 
 /**
@@ -310,10 +314,11 @@ export async function docxToPdf(
     import("html2canvas").then((m) => m.default),
   ]);
 
-  const buffer = await file.arrayBuffer();
+  const buffer = await readFileBytes(file);
+  const arrayBuffer = buffer.buffer as ArrayBuffer;
   let html: string;
   try {
-    const result = await convertToHtml({ arrayBuffer: buffer });
+    const result = await convertToHtml({ arrayBuffer });
     html = result.value;
   } catch {
     throw new Error(


### PR DESCRIPTION
## Summary

- make local Blob/File reads resilient to WebKit `NotReadableError` with a copied-byte snapshot and `FileReader` fallback
- allow same-file duplicate PDF merges and keep the raw browser error out of the UI
- disable file mutations during processing, reset stale results after reordering, and expose Start over after rejected-only selections
- strengthen browser output validation and add a same-PDF/WebKit-style regression test
- clean up pdf.js documents on render failures

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` — 76 passed
- `npm run build`
- `npm audit` — 0 vulnerabilities
- `npm run release:check`
- Playwright Chromium, Firefox, WebKit — 12 passed per engine
- interaction and network audits against local preview and production

No document uploads, conversion APIs, analytics, or trackers were added.
